### PR TITLE
feat: implement multi-slug support across various command handlers and utilities

### DIFF
--- a/backend/src/services/discord-commands/handlers/list-rules.handler.ts
+++ b/backend/src/services/discord-commands/handlers/list-rules.handler.ts
@@ -209,7 +209,11 @@ export class ListRulesHandler {
 
     try {
       const attribute = formatAttribute(rule.attribute_key, rule.attribute_value);
-      const slug = rule.slug || 'ALL';
+      let slug = rule.slug || 'ALL';
+      // Format multi-slug display with spaces after commas for readability
+      if (slug !== 'ALL' && slug.includes(',')) {
+        slug = slug.split(',').map(s => s.trim()).join(', ');
+      }
       const minItems = rule.min_items || 1;
       const ruleId = rule.id || 'N/A';
       const channelId = rule.channel_id || 'N/A';

--- a/backend/src/services/discord-commands/handlers/remove-rule.handler.ts
+++ b/backend/src/services/discord-commands/handlers/remove-rule.handler.ts
@@ -293,7 +293,11 @@ export class RemoveRuleHandler {
       // Add clean rule info for each removed rule using list format
       successful.forEach(s => {
         const attribute = formatAttribute(s.data.attribute_key, s.data.attribute_value);
-        const slug = s.data.slug || 'ALL';
+        let slug = s.data.slug || 'ALL';
+        // Format multi-slug display with spaces after commas for readability
+        if (slug !== 'ALL' && slug.includes(',')) {
+          slug = slug.split(',').map(s => s.trim()).join(', ');
+        }
         const minItems = s.data.min_items || 1;
         
         const ruleInfo = `ID: ${s.id} | Channel: <#${s.data.channel_id}> | Role: <@&${s.data.role_id}> | Slug: ${slug} | Attr: ${attribute} | Min: ${minItems}`;

--- a/backend/src/services/utils/match-rule.util.ts
+++ b/backend/src/services/utils/match-rule.util.ts
@@ -17,12 +17,9 @@ export function matchRule(
   channelId?: string
 ): boolean {
   // Slug matching: Wildcard support for 'ALL' or empty strings
+  // Supports comma-separated slugs for multi-collection rules
   // Allows rules to match all collections or specific collection slugs
-  const slugMatch =
-    !rule.slug ||
-    rule.slug === '' ||
-    rule.slug === 'ALL' ||
-    assets.some((a) => a.slug === rule.slug);
+  const slugMatch = checkSlugMatch(rule.slug, assets);
 
   // Channel matching: Null/undefined channel_id means rule applies to all channels
   // Otherwise must match the specific channel ID
@@ -50,4 +47,28 @@ export function matchRule(
 
   // All criteria must match for the rule to be satisfied
   return slugMatch && channelMatch && attrMatch && minItemsMatch;
+}
+
+/**
+ * Check if assets match the slug criteria
+ * Supports single slugs and comma-separated multi-slugs
+ * 
+ * @param ruleSlug - Single slug or comma-separated slugs from the rule
+ * @param assets - User's assets to check against
+ * @returns boolean - True if any asset matches any of the rule's slugs
+ */
+function checkSlugMatch(ruleSlug: string | undefined, assets: Asset[]): boolean {
+  // No slug specified or 'ALL' means match everything
+  if (!ruleSlug || ruleSlug === '' || ruleSlug === 'ALL') {
+    return true;
+  }
+  
+  // Parse comma-separated slugs
+  const slugs = ruleSlug
+    .split(',')
+    .map(s => s.trim())
+    .filter(s => s.length > 0);
+  
+  // Check if any asset matches any of the specified slugs
+  return assets.some(asset => slugs.includes(asset.slug || ''));
 }


### PR DESCRIPTION
This pull request adds robust support for rules that target multiple collections by allowing comma-separated slugs (multi-slug rules) throughout the backend. It ensures that multi-collection rules are consistently parsed, validated, and displayed, and that they work seamlessly with the asset ownership checks and Discord command handlers. The update also enforces that attribute-based filtering is only allowed for single-collection rules, improving both flexibility and data integrity.

**Multi-collection (multi-slug) rule support:**

* Added parsing and normalization of comma-separated slugs in the `DataService` and Discord command handlers, enabling rules to target multiple collections at once. [[1]](diffhunk://#diff-787fb42aa2af35437c15724cd04111fe517dfa754c9409987bf43539149171a7R462-R467) [[2]](diffhunk://#diff-787fb42aa2af35437c15724cd04111fe517dfa754c9409987bf43539149171a7L524-R572) [[3]](diffhunk://#diff-3adc9d7f7c3b5b32ffa8e40b20f9626670a89f789d3eca761f13e063c8b658c7R130-R144)
* Updated asset ownership queries to use an `IN` clause for multiple slugs and optimized for single-slug performance. [[1]](diffhunk://#diff-787fb42aa2af35437c15724cd04111fe517dfa754c9409987bf43539149171a7L476-R497) [[2]](diffhunk://#diff-787fb42aa2af35437c15724cd04111fe517dfa754c9409987bf43539149171a7L504-R524)

**Validation and rule logic:**

* Improved rule validation to individually check that each slug in a multi-slug rule exists in the database, and to enforce that attribute filtering is only possible for single-collection rules. Returns clear error messages for invalid cases.

**Display and formatting improvements:**

* Standardized the display of multi-slug rules by formatting them with spaces after commas for readability in rule listings and removal confirmations. [[1]](diffhunk://#diff-05701f42866f5c1c4f25931937aa66153795d2977089835e9adfb549b47425e7L212-R216) [[2]](diffhunk://#diff-bc9f8f9d214a84cd3ea97196088289d605b296af800f5bd2d9972011b7d59a79L296-R300)

**Rule matching logic:**

* Refactored the rule matching utility to support multi-slug rules by checking if any asset matches any of the specified slugs. [[1]](diffhunk://#diff-435b03cecfbf54f9fa80b4d9c1a9c33b8deec934c1cd81a1d687e15bc01d1607R20-R22) [[2]](diffhunk://#diff-435b03cecfbf54f9fa80b4d9c1a9c33b8deec934c1cd81a1d687e15bc01d1607R51-R74)